### PR TITLE
Upgrade Hyva themes compatibility

### DIFF
--- a/src/view/frontend/templates/widget/cart.phtml
+++ b/src/view/frontend/templates/widget/cart.phtml
@@ -1,0 +1,6 @@
+<?php ?>
+
+<div class="sequra-widget-wrapper"
+     data-content-type="sequra_core"
+     data-payment-method="">
+</div>

--- a/src/view/frontend/templates/widget/product.phtml
+++ b/src/view/frontend/templates/widget/product.phtml
@@ -1,0 +1,6 @@
+<?php ?>
+
+<div class="sequra-widget-wrapper"
+     data-content-type="sequra_core"
+     data-payment-method="">
+</div>

--- a/src/view/frontend/templates/widget_initializer.phtml
+++ b/src/view/frontend/templates/widget_initializer.phtml
@@ -35,7 +35,7 @@
                 hideAllMiniWidgets();
             }
 
-            if (!config.widgetConfig.hasOwnProperty('merchant')) {
+            if (!config.widgetConfig.hasOwnProperty('merchantId')) {
                 return;
             }
 
@@ -185,7 +185,7 @@
                 products.push(product.id)
             })
             var sequraConfigParams = {
-                merchant: config.widgetConfig.merchant,
+                merchant: config.widgetConfig.merchantId,
                 assetKey: config.widgetConfig.assetKey,
                 products: products,
                 scriptUri: config.widgetConfig.scriptUri,


### PR DESCRIPTION
### What is the goal?

* Upgrade Hyvä Themes compatibility module to work with latest Magento plugin changes.

### References

* **Issue:** [LIS-84](https://sequra.atlassian.net/browse/LIS-84)

### How is it being implemented?

* Updated CORE version  
* Reverted deleted methods from Widget Initializer  
* Refactored code to be compatible with CORE response  

### How is it tested?

* Manual tests  
  * Install SeQura plugin  
  * Install SeQura Hyvä compatibility plugin  
  * Enable and set up widgets on base SeQura plugin  
  * Set Theme to Hyvä  
  * Test widget display  
  * Set Theme to Luma  
  * Test native widget display  


[LIS-84]: https://sequra.atlassian.net/browse/LIS-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ