### PR TITLE
Fix merchant key in Hyvä widget initializer (TIJ-3995)

### DIFF
--- a/src/view/frontend/templates/widget_initializer.phtml
+++ b/src/view/frontend/templates/widget_initializer.phtml
@@ -33,7 +33,7 @@ $widgetData = $block->getWidgetInitializeData();
                         thousandSeparator: "<?= $block->escapeQuote($widgetData['thousandSeparator']); ?>",
                         decimalSeparator: "<?= $block->escapeQuote($widgetData['decimalSeparator']); ?>",
                         locale: "<?= $block->escapeQuote($widgetData['locale']); ?>",
-                        merchant: "<?= $block->escapeQuote($widgetData['merchantId']); ?>",
+                        merchant: "<?= $block->escapeQuote($widgetData['merchant']); ?>",
                         assetKey: "<?= $block->escapeQuote($widgetData['assetKey']); ?>",
                         products: <?= json_encode($widgetData['products'],
                                 JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR); ?>


### PR DESCRIPTION
### What is the goal?

Fix a regression in the Hyvä widget initializer template that broke promotional widget rendering on Hyvä storefronts. Reported by a merchant testing on Magento 2.4.8-p4.

The template referenced `$widgetData['merchantId']`, but `PromotionalWidgetsCheckoutResponse::toArray()` (in `integration-core`) returns the merchant identifier under the key `merchant`. This produced an `Undefined array key "merchantId"` warning on every storefront page that renders the widget initializer and left `window.SequraWidgetFacade.merchant` empty, so the SeQura SDK could not load credit agreements.

The Luma template in `magento2-core` already uses the correct key (`$widgetData['merchant']`); only the Hyvä-compat template diverged.

### References
* **Issue:** [TIJ-3995](https://sequra.atlassian.net/browse/TIJ-3995), [PAR-784](https://sequra.atlassian.net/browse/PAR-784)
* **Related pull-requests:** —
* **Honeybadger errors:** —
* **Sentry errors:** —
* **Any other references:** —

### How is it being implemented?

Single-line change in `src/view/frontend/templates/widget_initializer.phtml`: read `$widgetData['merchant']` instead of `$widgetData['merchantId']`. No other files in `src/` referenced the wrong key.

The bug was introduced in commit `10ad2abe` ("Fix code review issues", 2025-10-14).

### Caveats

The merchant report on TIJ-3995 also describes two other problems that are **not** fixed by this PR and are out of scope for this module:

- A `DisableTmpl` REST validation error on place-order in the Hyvä checkout — this module ships only widget templates and has no Hyvä checkout/payment integration. Adding one is a feature, not a bugfix.
- Admin config-page JS errors (`removeClassName` undefined; `.collapse is not a function`) — these come from Prototype.js / Magento Bootstrap shims, not from our admin assets. Likely a Magento 2.4.8-p4 / PHP 8.4 environmental issue upstream.

### Does it affect (changes or update) any sensitive data?

No.

### How is it tested?

Manual verification on a Hyvä-themed Magento 2.4.8 install:

- [ ] `grep -rn "merchantId" src/` returns nothing.
- [ ] No `Undefined array key "merchantId"` warning in `var/log/` or in the page output when loading homepage / PDP / cart.
- [ ] In the browser console, `window.SequraWidgetFacade.merchant` is the configured merchant reference (e.g. `dummy_services`), not an empty string.
- [ ] On a PDP that meets widget conditions, the SeQura promotional widget renders with the correct merchant — i.e. the SDK loads from `scriptUri` and `Sequra.computeCreditAgreements` returns a non-empty object.

### How is it going to be deployed?

Standard deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TIJ-3995]: https://sequra.atlassian.net/browse/TIJ-3995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAR-784]: https://sequra.atlassian.net/browse/PAR-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ